### PR TITLE
fix various issue

### DIFF
--- a/demo/IconDemo/ViewModels/ExportViewModel.cs
+++ b/demo/IconDemo/ViewModels/ExportViewModel.cs
@@ -6,17 +6,17 @@ using IconDemo.Models;
 
 namespace IconDemo.ViewModels;
 
-public partial class ExportViewModel: ObservableObject
+public partial class ExportViewModel : ObservableObject
 {
     private SettingPanelViewModel _settingPanelViewModel;
     private IconInfo? _iconInfo;
-    
+
     [ObservableProperty] private string? _globalStyle;
     [ObservableProperty] private string? _globalResource;
     [ObservableProperty] private string? _icon;
     [ObservableProperty] private bool _useLocalColor;
     [ObservableProperty] private bool _hasIconInfo;
-    
+
     public ExportViewModel(SettingPanelViewModel settingPanelViewModel, IconInfo? iconType)
     {
         _settingPanelViewModel = settingPanelViewModel;
@@ -29,65 +29,77 @@ public partial class ExportViewModel: ObservableObject
 
     private void GenerateGlobalStyle()
     {
-        StringBuilder sb = new StringBuilder();
-        sb.AppendLine("<Style Selector=\":is(iconica|IconParkBase)\">");
-        sb.AppendLine($"    <Setter Property=\"OuterFill\" Value=\"{{DynamicResource IconOuterFillBrush}}\" />");
-        sb.AppendLine($"    <Setter Property=\"OuterStroke\" Value=\"{{DynamicResource IconOuterStrokeBrush}}\" />");
-        sb.AppendLine($"    <Setter Property=\"InnerFill\" Value=\"{{DynamicResource IconInnerFillBrush}}\" />");
-        sb.AppendLine($"    <Setter Property=\"InnerStroke\" Value=\"{{DynamicResource IconInnerStrokeBrush}}\" />");
-        sb.AppendLine($"    <Setter Property=\"FallbackBrush\" Value=\"{{DynamicResource IconFallbackBrush}}\" />");
-        sb.AppendLine("</Style>");
-        GlobalStyle = sb.ToString();
+        GlobalStyle =
+            """
+            <Style Selector=":is(iconica|IconParkBase)">
+                <Setter Property="OuterFill" Value="{{DynamicResource IconOuterFillBrush}}" />
+                <Setter Property="OuterStroke" Value="{{DynamicResource IconOuterStrokeBrush}}" />
+                <Setter Property="InnerFill" Value="{{DynamicResource IconInnerFillBrush}}" />
+                <Setter Property="InnerStroke" Value="{{DynamicResource IconInnerStrokeBrush}}" />
+                <Setter Property="FallbackBrush" Value="{{DynamicResource IconFallbackBrush}}" />
+            </Style>
+            """;
     }
-    
+
     private void GenerateGlobalResource()
     {
-        StringBuilder sb = new StringBuilder();
-        sb.AppendLine("<ResourceDictionary>");
-        sb.AppendLine("    <ResourceDictionary.ThemeDictionaries>");
-        sb.AppendLine("        <ResourceDictionary x:Key=\"Light\">");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconOuterFillBrush\" Color=\"{_settingPanelViewModel._lightOuterFillColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconOuterStrokeBrush\" Color=\"{_settingPanelViewModel._lightOuterStrokeColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconInnerFillBrush\" Color=\"{_settingPanelViewModel._lightInnerFillColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconInnerStrokeBrush\" Color=\"{_settingPanelViewModel._lightInnerStrokeColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconFallbackBrush\" Color=\"{_settingPanelViewModel._lightFallbackColor}\" />");
-        sb.AppendLine("        </ResourceDictionary>");
-        sb.AppendLine("        <ResourceDictionary x:Key=\"Dark\">");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconOuterFillBrush\" Color=\"{_settingPanelViewModel._darkOuterFillColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconOuterStrokeBrush\" Color=\"{_settingPanelViewModel._darkOuterStrokeColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconInnerFillBrush\" Color=\"{_settingPanelViewModel._darkInnerFillColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconInnerStrokeBrush\" Color=\"{_settingPanelViewModel._darkInnerStrokeColor}\" />");
-        sb.AppendLine($"            <SolidColorBrush x:Key=\"IconFallbackBrush\" Color=\"{_settingPanelViewModel._darkFallbackColor}\" />");
-        sb.AppendLine("        </ResourceDictionary>");
-        sb.AppendLine("    </ResourceDictionary.ThemeDictionaries>");
-        sb.AppendLine("</ResourceDictionary>");
-        GlobalResource = sb.ToString();
+        GlobalResource =
+            $"""
+             <ResourceDictionary>
+                 <ResourceDictionary.ThemeDictionaries>
+                     <ResourceDictionary x:Key="Light">
+                         <SolidColorBrush x:Key="IconOuterFillBrush" Color="{_settingPanelViewModel._lightOuterFillColor}" />
+                         <SolidColorBrush x:Key="IconOuterStrokeBrush" Color="{_settingPanelViewModel._lightOuterStrokeColor}" />
+                         <SolidColorBrush x:Key="IconInnerFillBrush" Color="{_settingPanelViewModel._lightInnerFillColor}" />
+                         <SolidColorBrush x:Key="IconInnerStrokeBrush" Color="{_settingPanelViewModel._lightInnerStrokeColor}" />
+                         <SolidColorBrush x:Key="IconFallbackBrush" Color="{_settingPanelViewModel._lightFallbackColor}" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="Dark">
+                         <SolidColorBrush x:Key="IconOuterFillBrush" Color="{_settingPanelViewModel._darkOuterFillColor}" />
+                         <SolidColorBrush x:Key="IconOuterStrokeBrush" Color="{_settingPanelViewModel._darkOuterStrokeColor}" />
+                         <SolidColorBrush x:Key="IconInnerFillBrush" Color="{_settingPanelViewModel._darkInnerFillColor}" />
+                         <SolidColorBrush x:Key="IconInnerStrokeBrush" Color="{_settingPanelViewModel._darkInnerStrokeColor}" />
+                         <SolidColorBrush x:Key="IconFallbackBrush" Color="{_settingPanelViewModel._darkFallbackColor}" />
+                     </ResourceDictionary>
+                 </ResourceDictionary.ThemeDictionaries>
+             </ResourceDictionary>
+             """;
     }
-    
+
     private void GenerateIcon()
     {
         if (_iconInfo is null) return;
-        StringBuilder sb = new StringBuilder();
-        sb.AppendLine($"<iconica:{_iconInfo.ClassName} Width=\"{_settingPanelViewModel.Size}\" Height=\"{_settingPanelViewModel.Size}\"");
+
+        var element =
+            $"""
+             <iconpark:{_iconInfo.ClassName} Width="{_settingPanelViewModel.Size}" Height="{_settingPanelViewModel.Size}"
+             """;
         if (UseLocalColor)
         {
-            sb.AppendLine($"    OuterFill=\"{{DynamicResource IconOuterFillBrush}}\"");
-            sb.AppendLine($"    OuterStroke=\"{{DynamicResource IconOuterStrokeBrush}}\"");
-            sb.AppendLine($"    InnerFill=\"{{DynamicResource IconInnerFillBrush}}\"");
-            sb.AppendLine($"    InnerStroke=\"{{DynamicResource IconInnerStrokeBrush}}\"");
-            sb.AppendLine($"    FallbackBrush=\"{{DynamicResource IconFallbackBrush}}\"");
+            element =
+                $$$"""
+                   {{{element}}}
+                       OuterFill="{{DynamicResource IconOuterFillBrush}}"
+                       OuterStroke="{{DynamicResource IconOuterStrokeBrush}}"
+                       InnerFill="{{DynamicResource IconInnerFillBrush}}"
+                       InnerStroke="{{DynamicResource IconInnerStrokeBrush}}"
+                       FallbackBrush="{{DynamicResource IconFallbackBrush}}"
+                   """;
         }
-        sb.AppendLine($"    StrokeWidth=\"{_settingPanelViewModel.StrokeWidth}\"");
-        sb.AppendLine($"    LineCap=\"Round\"");
-        sb.AppendLine($"    LineJoin=\"Round\"");
-        sb.AppendLine($"    Mode=\"{(_settingPanelViewModel.SelectedMode)}\"");
-        sb.AppendLine("    />");
-        Icon = sb.ToString();
+
+        element =
+            $"""
+             {element}
+                 StrokeWidth="{_settingPanelViewModel.StrokeWidth}"
+                 LineCap="Round"
+                 LineJoin="Round"
+                 Mode="{_settingPanelViewModel.SelectedMode}" />");
+             """;
+        Icon = element;
     }
-    
+
     partial void OnUseLocalColorChanged(bool value)
     {
         GenerateIcon();
     }
-    
 }

--- a/demo/IconDemo/ViewModels/ExportViewModel.cs
+++ b/demo/IconDemo/ViewModels/ExportViewModel.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text;
-using Avalonia.Metadata;
 using CommunityToolkit.Mvvm.ComponentModel;
 using IconDemo.Models;
 
@@ -31,7 +28,7 @@ public partial class ExportViewModel : ObservableObject
     {
         GlobalStyle =
             """
-            <Style Selector=":is(iconica|IconParkBase)">
+            <Style Selector=":is(iconpark|IconParkBase)">
                 <Setter Property="OuterFill" Value="{{DynamicResource IconOuterFillBrush}}" />
                 <Setter Property="OuterStroke" Value="{{DynamicResource IconOuterStrokeBrush}}" />
                 <Setter Property="InnerFill" Value="{{DynamicResource IconInnerFillBrush}}" />
@@ -53,8 +50,8 @@ public partial class ExportViewModel : ObservableObject
                          <SolidColorBrush x:Key="IconInnerFillBrush" Color="{_settingPanelViewModel._lightInnerFillColor}" />
                          <SolidColorBrush x:Key="IconInnerStrokeBrush" Color="{_settingPanelViewModel._lightInnerStrokeColor}" />
                          <SolidColorBrush x:Key="IconFallbackBrush" Color="{_settingPanelViewModel._lightFallbackColor}" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="Dark">
+                     </ResourceDictionary>
+                     <ResourceDictionary x:Key="Dark">
                          <SolidColorBrush x:Key="IconOuterFillBrush" Color="{_settingPanelViewModel._darkOuterFillColor}" />
                          <SolidColorBrush x:Key="IconOuterStrokeBrush" Color="{_settingPanelViewModel._darkOuterStrokeColor}" />
                          <SolidColorBrush x:Key="IconInnerFillBrush" Color="{_settingPanelViewModel._darkInnerFillColor}" />
@@ -69,10 +66,11 @@ public partial class ExportViewModel : ObservableObject
     private void GenerateIcon()
     {
         if (_iconInfo is null) return;
-
         var element =
             $"""
-             <iconpark:{_iconInfo.ClassName} Width="{_settingPanelViewModel.Size}" Height="{_settingPanelViewModel.Size}"
+             <iconpark:{_iconInfo.ClassName}
+                 Width="{_settingPanelViewModel.Size}"
+                 Height="{_settingPanelViewModel.Size}"
              """;
         if (UseLocalColor)
         {
@@ -93,7 +91,7 @@ public partial class ExportViewModel : ObservableObject
                  StrokeWidth="{_settingPanelViewModel.StrokeWidth}"
                  LineCap="Round"
                  LineJoin="Round"
-                 Mode="{_settingPanelViewModel.SelectedMode}" />");
+                 Mode="{_settingPanelViewModel.SelectedMode}" />
              """;
         Icon = element;
     }

--- a/demo/IconDemo/Views/ExportView.axaml
+++ b/demo/IconDemo/Views/ExportView.axaml
@@ -13,7 +13,9 @@
     <Grid RowDefinitions="Auto, *">
         <StackPanel Grid.Row="0" Orientation="Horizontal">
             <TextBlock Text="XML命名空间："/>
-            <SelectableTextBlock Text='xmlns:iconica="https://irihi.tech/iconica"'/>
+            <SelectableTextBlock>
+                https://irihi.tech/iconica/iconpark
+            </SelectableTextBlock>
         </StackPanel>
         <TabControl Grid.Row="1" >
             <TabItem Header="全局样式" >

--- a/demo/IconDemo/Views/IconDetailView.axaml
+++ b/demo/IconDemo/Views/IconDetailView.axaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dataTemplates="clr-namespace:IconDemo.DataTemplates"
-    xmlns:iconica="https://irihi.tech/iconica/iconpark"
+    xmlns:iconpark="https://irihi.tech/iconica/iconpark"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:u="https://irihi.tech/ursa"
     xmlns:viewModels="clr-namespace:IconDemo.ViewModels"
@@ -12,7 +12,7 @@
     x:DataType="viewModels:IconDetailViewModel"
     mc:Ignorable="d">
     <UserControl.Styles>
-        <Style Selector=":is(iconica|IconParkBase)">
+        <Style Selector=":is(iconpark|IconParkBase)">
             <Setter Property="Width" Value="{DynamicResource IconSize}" />
             <Setter Property="Height" Value="{DynamicResource IconSize}" />
             <Setter Property="Mode" Value="{DynamicResource IconMode}" />

--- a/demo/IconDemo/Views/IconViewer.axaml
+++ b/demo/IconDemo/Views/IconViewer.axaml
@@ -3,7 +3,7 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:iconica="https://irihi.tech/iconica/iconpark"
+    xmlns:iconpark="https://irihi.tech/iconica/iconpark"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:u="https://irihi.tech/ursa"
     xmlns:viewModels="clr-namespace:IconDemo.ViewModels"
@@ -46,7 +46,7 @@
             Grid.Row="1"
             Background="{DynamicResource SemiBackground0}">
             <ScrollViewer.Styles>
-                <Style Selector=":is(iconica|IconParkBase)">
+                <Style Selector=":is(iconpark|IconParkBase)">
                     <Setter Property="Width" Value="36" />
                     <Setter Property="Height" Value="36" />
                     <Setter Property="Mode" Value="{DynamicResource IconMode}" />

--- a/demo/IconDemo/Views/MainWindow.axaml
+++ b/demo/IconDemo/Views/MainWindow.axaml
@@ -7,7 +7,7 @@
     xmlns:u="https://irihi.tech/ursa"
     xmlns:views="clr-namespace:IconDemo.Views"
     xmlns:vm="using:IconDemo.ViewModels"
-    xmlns:iconica="https://irihi.tech/iconica/iconpark"
+    xmlns:iconpark="https://irihi.tech/iconica/iconpark"
     Name="root"
     Title="IconDemo"
     MinHeight="600"
@@ -30,7 +30,7 @@
     <u:UrsaWindow.RightContent>
         <StackPanel Orientation="Horizontal">
             <Button Theme="{DynamicResource BorderlessButton}" Classes="Tertiary" Padding="8" Command="{Binding SaveDialogCommand}">
-                <iconica:Export Width="16" Height="16" Mode="Fill" StrokeWidth="6" OuterStroke="{DynamicResource SemiGrey8}"/>
+                <iconpark:Export Width="16" Height="16" Mode="Fill" StrokeWidth="6" OuterStroke="{DynamicResource SemiGrey8}"/>
             </Button>
             <u:ThemeToggleButton />
         </StackPanel>

--- a/src/Irihi.Iconica.IconPark/Irihi.Iconica.IconPark.csproj
+++ b/src/Irihi.Iconica.IconPark/Irihi.Iconica.IconPark.csproj
@@ -10,6 +10,7 @@
         <PackageId>Irihi.Iconica.IconPark</PackageId>
         <PackageIcon>irihi.png</PackageIcon>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Authors>IRIHI Technology Co., Ltd. 上海铱泓科技服务有限公司</Authors>
@@ -24,6 +25,7 @@
         <None Include="irihi.png" Pack="true" PackagePath=""/>
         <None Include="../../LICENSE" Pack="true" PackagePath=""/>
         <None Include="../../NOTICE" Pack="true" PackagePath=""/>
+        <None Include="../../README.md" Pack="true" PackagePath=""/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the icon namespace throughout the demo application and refactors the generation of XAML strings for exporting icons and resources. Additionally, it improves the NuGet packaging for the `Irihi.Iconica.IconPark` library by including the README file. The main themes are namespace consistency, code simplification, and packaging enhancements.

**Namespace consistency in XAML files:**
* Changed all references from `iconica` to `iconpark` in XAML files (`IconDetailView.axaml`, `IconViewer.axaml`, `MainWindow.axaml`) to ensure consistent usage of the correct icon namespace. [[1]](diffhunk://#diff-82ea41df3fa6ccef912b536f694a1f3e5c2d4d26edf55ef8bd1bd0fb4d23d077L7-R15) [[2]](diffhunk://#diff-bcb28ddc3ea4078c0693369768d375f9fafe030541566be55a13e296a117b422L6-R6) [[3]](diffhunk://#diff-bcb28ddc3ea4078c0693369768d375f9fafe030541566be55a13e296a117b422L49-R49) [[4]](diffhunk://#diff-a0895c7f5b997ff25df0c23eb0c82d8cd0bba41108fa5b59c1e9f4603da33662L10-R10) [[5]](diffhunk://#diff-a0895c7f5b997ff25df0c23eb0c82d8cd0bba41108fa5b59c1e9f4603da33662L33-R33)

**Code simplification and modernization:**
* Refactored the `ExportViewModel.cs` methods to use raw string literals (`"""`) for generating XAML markup, replacing manual `StringBuilder` usage. This makes the code more readable and maintainable.

**Packaging improvements:**
* Updated the `Irihi.Iconica.IconPark.csproj` file to include the `README.md` in the NuGet package and reference it as the package's readme file, improving documentation for consumers. [[1]](diffhunk://#diff-8f7fbf865c1d6a9904aa32ecda905e6ba4c162f2f934a234d7ea4d92f6499824R13) [[2]](diffhunk://#diff-8f7fbf865c1d6a9904aa32ecda905e6ba4c162f2f934a234d7ea4d92f6499824R28)